### PR TITLE
Metric graphs have a minimum height

### DIFF
--- a/www/app/metric-details/metricDetail.js
+++ b/www/app/metric-details/metricDetail.js
@@ -46,7 +46,9 @@ angular
 			};
 
 			var pos = $('.graph').position();
-			this.height = window.innerHeight - pos.top - 100;
+
+			// Sets height of graph with a minimum of 500px
+			this.height = Math.max(window.innerHeight - pos.top - 100, 500);
 
 			$scope.$watchCollection('modifier', function(val, old, scope) {
 				if ($routeParams.stat !== val.stat) {


### PR DESCRIPTION
We had some complaints from users that the metric graphs ended up unusable given certain browser viewport dimensions. This sets a minimum height so that doesn't happen.

Status: **Ready for Review**

### Changes
- Maintain original logic for setting metric graph height, but provide a minimum of 500px (in the case of very tiny desktop browsers or mobile users)