### PR TITLE
Fix Gruntfile static content serving

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@ module.exports = function(grunt) {
 	var couchdb = require('./test/util').config({
 		log: 1
 	}).couch;
+	var serveStatic = require('serve-static');
 	var path = require('path');
 	var jqplot = [
 		'jquery.jqplot.min.js',
@@ -173,7 +174,7 @@ module.exports = function(grunt) {
 						}
 						middlewares.push(require('grunt-connect-proxy/lib/utils').proxyRequest);
 						options.base.forEach(function(base) {
-							middlewares.push(connect.static(base));
+							middlewares.push(serveStatic(base));
 						});
 						return middlewares;
 					},

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "nano": "~6.1.5",
     "q": "~1.4.1",
     "sauce-tunnel": "^2.2.3",
-    "semver": "^5.0.1"
+    "semver": "^5.0.1",
+    "serve-static": "^1.10.0"
   },
   "devDependencies": {
     "bunyan": "~1.4.0",


### PR DESCRIPTION
`connect.static` was removed from connect in version 3.0 and put into a separate `serve-static` package. 

https://github.com/senchalabs/connect#middleware

`grunt-contrib-connect` updated to version 3 of connect but made it a minor release rather then a major release. If you `npm install` to the lastest version the grunt tasks break.

https://github.com/gruntjs/grunt-contrib-connect/commit/c7fb9588ae7855f462793c5060a9c75adbe44694

This change replaces `connect.static` with `serve-static` in the Gruntfile.