### PR TITLE
Add browser-perf runner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ perfjankie({
 
   SAUCE_USERNAME: process.env.SAUCE_USERNAME, // If using Saucelabs
   SAUCE_ACCESSKEY: process.env.SAUCE_ACCESSKEY, // If using Saucelabs
+  
+  browserPerfRunner: false, // defaults to false, see usage below
 
   /* A way to log the information - can be bunyan, or grunt logs. */
   log: { // Expects the following methods,  
@@ -89,6 +91,34 @@ perfjankie({
 ```
 
 Other options that can be passed include `preScript`, `actions`, `metrics`, `preScriptFile`, etc. Note that most of these options are similar to the options passed to browser-perf. Refer to the [browser-perf options](https://github.com/axemclion/browser-perf/wiki/Node-Module---API) for a mode detailed explanation. 
+
+#### Defining a Runner
+
+In some rare cases, you may want to define a runner to work with perfjankie.  For example, you want your E2E test framework to integrate with perfjankie so you can check or track various performance metrics.
+
+Example:
+
+```
+/* ... */
+browserPerfRunner: {
+	// runner - instance of the runner created by browser-perf
+	// runnerDone - callback function for when you want to stop the runner
+    onStart: (runner, runnerDone) => {
+	    this.runner = runner;
+	    this.runnerDone = runnerDone;
+    }
+},
+/* ... */
+```
+
+When you want to stop the runner, you can execute something similar to the following:
+
+```
+this.runner.stop((err, metrics) => {
+    // Runner is done, now return control to perfjankie
+    this.runnerDone(err, metrics);
+});
+```
 
 ### Grunt Task
 To run perfjankie as a Grunt task, simple load task using `grunt.loadNpmTasks('perfjankie');`, define a `perfjankie` task and pass in all the options from above as options to the Grunt task. [Here](https://github.com/axemclion/perfslides/blob/38b4f6e246c5ab971ce2957ec78bb701dbbc3038/Gruntfile.js#L57) is an example. 

--- a/lib/options.js
+++ b/lib/options.js
@@ -30,6 +30,8 @@ module.exports = function(config) {
 		config.callback = noop;
 	}
 
+	config.browserPerfRunner = config.browserPerfRunner || false;
+
 	if (typeof config.couch === 'undefined') {
 		config.couch = {};
 	}

--- a/lib/perfTests.js
+++ b/lib/perfTests.js
@@ -5,30 +5,53 @@ module.exports = function(config) {
 	if (config.couch.onlyUpdateSite) {
 		dfd.resolve();
 	} else {
-		var browserPerf = config.browserPerf || require('browser-perf'),
-			log = config.log;
 
-		log.debug('Starting Browser Perf');
-		browserPerf(config.url, function(err, results) {
-			if (err) {
-				dfd.reject(err);
-			} else {
-				log.debug('Got Browser Perf results back, now saving the results');
-				dfd.resolve(results);
-			}
-		}, {
-			browsers: config.browsers,
-			selenium: config.selenium,
-			debugBrowser: config.debug,
-			preScript: config.preScript,
-			preScriptFile: config.preScriptFile,
-			actions: config.actions,
-			metrics: config.metrics,
-			SAUCE_ACCESSKEY: config.SAUCE_ACCESSKEY || undefined,
-			SAUCE_USERNAME: config.SAUCE_USERNAME || undefined,
-			BROWSERSTACK_USERNAME: config.BROWSERSTACK_USERNAME || undefined,
-			BROWSERSTACK_KEY: config.BROWSERSTACK_KEY || undefined
-		});
+        var browserPerf = config.browserPerf || require('browser-perf'),
+            log = config.log;
+
+        if (config.browserPerfRunner) {
+            const browserPerfRunner = new browserPerf.runner(config.browserPerfRunner);
+            browserPerfRunner.start(config.browserPerfRunner.sessionId, () => {
+                log.debug('Starting Browser Perf Runner');
+                if (typeof config.browserPerfRunner.onStart==='function') {
+                    var doneCallback = function (err, results) {
+                        if (err) {
+                            dfd.reject(err);
+                        } else {
+                            log.debug('Got Browser Perf Runner results back, now saving the results');
+                            results._browserName  = config.browserPerfRunner.browserName;
+                            results._url  = config.url;
+                            dfd.resolve([results]);
+                        }
+                    };
+                    config.browserPerfRunner.onStart.apply({}, [browserPerfRunner, doneCallback]);
+				} else {
+                    log.fatal('Browser Perf Runner onStart callback is undefined');
+                }
+            });
+        } else {
+			log.debug('Starting Browser Perf');
+			browserPerf(config.url, function (err, results) {
+				if (err) {
+					dfd.reject(err);
+				} else {
+					log.debug('Got Browser Perf results back, now saving the results');
+					dfd.resolve(results);
+				}
+			}, {
+				browsers: config.browsers,
+				selenium: config.selenium,
+				debugBrowser: config.debug,
+				preScript: config.preScript,
+				preScriptFile: config.preScriptFile,
+				actions: config.actions,
+				metrics: config.metrics,
+				SAUCE_ACCESSKEY: config.SAUCE_ACCESSKEY || undefined,
+				SAUCE_USERNAME: config.SAUCE_USERNAME || undefined,
+				BROWSERSTACK_USERNAME: config.BROWSERSTACK_USERNAME || undefined,
+				BROWSERSTACK_KEY: config.BROWSERSTACK_KEY || undefined
+			});
+		}
 	}
 	return dfd.promise;
 };

--- a/lib/perfTests.js
+++ b/lib/perfTests.js
@@ -8,9 +8,21 @@ module.exports = function(config) {
 
         var browserPerf = config.browserPerf || require('browser-perf'),
             log = config.log;
-
+		const perfConfig = {
+            browsers: config.browsers,
+            selenium: config.selenium,
+            debugBrowser: config.debug,
+            preScript: config.preScript,
+            preScriptFile: config.preScriptFile,
+            actions: config.actions,
+            metrics: config.metrics,
+            SAUCE_ACCESSKEY: config.SAUCE_ACCESSKEY || undefined,
+            SAUCE_USERNAME: config.SAUCE_USERNAME || undefined,
+            BROWSERSTACK_USERNAME: config.BROWSERSTACK_USERNAME || undefined,
+            BROWSERSTACK_KEY: config.BROWSERSTACK_KEY || undefined
+        };
         if (config.browserPerfRunner) {
-            const browserPerfRunner = new browserPerf.runner(config.browserPerfRunner);
+            const browserPerfRunner = new browserPerf.runner(perfConfig);
             browserPerfRunner.start(config.browserPerfRunner.sessionId, () => {
                 log.debug('Starting Browser Perf Runner');
                 if (typeof config.browserPerfRunner.onStart==='function') {
@@ -38,19 +50,7 @@ module.exports = function(config) {
 					log.debug('Got Browser Perf results back, now saving the results');
 					dfd.resolve(results);
 				}
-			}, {
-				browsers: config.browsers,
-				selenium: config.selenium,
-				debugBrowser: config.debug,
-				preScript: config.preScript,
-				preScriptFile: config.preScriptFile,
-				actions: config.actions,
-				metrics: config.metrics,
-				SAUCE_ACCESSKEY: config.SAUCE_ACCESSKEY || undefined,
-				SAUCE_USERNAME: config.SAUCE_USERNAME || undefined,
-				BROWSERSTACK_USERNAME: config.BROWSERSTACK_USERNAME || undefined,
-				BROWSERSTACK_KEY: config.BROWSERSTACK_KEY || undefined
-			});
+			}, perfConfig);
 		}
 	}
 	return dfd.promise;


### PR DESCRIPTION
This adds support for calling a browser-perf runner.

browser-perf's runner if you are not familiar:
https://github.com/axemclion/browser-perf/blob/master/lib/runner.js

it is possible to do performance analysis on a test written in Nightwatch (cool)...!

Example usage in Nightwatch for starting the runner:
```
    browser.perform((client, performDone) => {

        const config = {
            name: browser.currentTest.name,
            suite: browser.currentTest.module,
            url: 'Nightwatch',
            time: new Date().getTime(),
            couch: {
                server: 'http://perfjankie:perfjankie@localhost:5984',
                database: 'perfjankie-test'
            },
            browserPerfRunner: {
                selenium: `http://${browser.globals.test_settings.selenium_host}:${browser.globals.test_settings.selenium_port}${browser.globals.test_settings.default_path_prefix}`,
                browserName: 'chrome',
                sessionId: client.sessionId,
                onStart: (runner, runnerDone) => {
                    this.runner = runner;
                    this.runnerDone = runnerDone;

                    // Finish the Nightwatch perform operation
                    performDone();
                }
            },
            log: {
                fatal: console.error.bind(console),
                error: console.error.bind(console),
                warn: console.warn.bind(console),
                info: console.info.bind(console),
                debug: console.log.bind(console),
                trace: console.log.bind(console)
            }
        };

        perfjankie(config);
    });
```

For stopping the runner in Nightwatch:
```
    this.browser.perform((client, performDone) => {
        this.runner.stop((err, metrics) => {
            // console.log(metrics);

            // Finish perfjankie
            this.runnerDone(err, metrics);

            // Finish browser
            this.browser.end();

            // Finish perform
            performDone();

        });
    });
```

Example Nightwatch config:
```
    "test_settings": {
        "default": {
            "selenium_port": 9515,
            "selenium_host": "localhost",
            "default_path_prefix" : "",
            "launch_url": "http://localhost:8000",
            "desiredCapabilities": {
                "browserName": "chrome",
                "acceptSslCerts": true,
                "chromeOptions": {
                    "perfLoggingPrefs":{
                        "traceCategories":"blink.console,devtools.timeline,disabled-by-default-devtools.timeline,toplevel,disabled-by-default-devtools.timeline.frame,benchmark"
                    },
                    "args":[
                        "--enable-gpu-benchmarking",
                        "--enable-thread-composting"
                    ]
                },
                "loggingPrefs":{
                    "performance":"ALL"
                }
            }
        }
```

